### PR TITLE
DO NOT MERGE: Demonstrate GORM mongo cascade when it shouldn't

### DIFF
--- a/complete/grails-app/controllers/demo/ProductLineController.groovy
+++ b/complete/grails-app/controllers/demo/ProductLineController.groovy
@@ -1,0 +1,12 @@
+package demo
+
+
+import grails.rest.*
+import grails.converters.*
+
+class ProductLineController extends RestfulController<ProductLine> {
+	static responseFormats = ['json', 'xml']
+    ProductLineController() {
+        super(ProductLine)
+    }
+}

--- a/complete/grails-app/domain/demo/Product.groovy
+++ b/complete/grails-app/domain/demo/Product.groovy
@@ -8,6 +8,8 @@ class Product {
     String name
     Double price
 
+    ProductLine productLine
+
     //tag::constraints[]
     static constraints = {
         name blank: false

--- a/complete/grails-app/domain/demo/ProductLine.groovy
+++ b/complete/grails-app/domain/demo/ProductLine.groovy
@@ -1,0 +1,8 @@
+package demo
+
+class ProductLine {
+    String name
+
+    static constraints = {
+    }
+}

--- a/complete/grails-app/views/product/_product.gson
+++ b/complete/grails-app/views/product/_product.gson
@@ -9,4 +9,5 @@ json {
     id product.id
     name product.name
     price "${currency.symbol}${product.price}"
+    productLine g.render(product.productLine)
 }


### PR DESCRIPTION
http://gorm.grails.org/latest/hibernate/manual/index.html#cascades

```
If you do not define belongsTo then no cascades will happen and you will
have to manually save each object (except in the case of the
one-to-many, in which case saves will cascade automatically if a new
instance is in a hasMany collection).
```

That doesn't seem to be the case. In the following, I create a product line, then create a product associated to that product line, but included in the `productLine` object is a mis-spelling of the product line name. Finally, we can see at the end that the product line was affected: this change was targeted at the product but cascaded to the product line.

```sh
little_stuff_id=$(
  curl -XPOST '0:8080/productLine'  --data '{"name":"Little Stuff"}'   -H 'Content-type: application/json'
)

curl -XPOST '0:8080/product'  --data '
  {"productLine":{"id":"'$little_stuff_id'", "name":"messed up stuff!"},
  "name":"Ship",
  "price": "100"
}' -H 'Content-type: application/json'

curl 0:8080/productLine/$little_stuff_id
```